### PR TITLE
Cross-platform hosting: stdio bridge with daemon auto-start, dnx/NuGet tool publishing

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,51 @@
+name: Publish to NuGet
+
+# Pushing a tag like v1.2.3 packs Roslynk at that version and publishes it to NuGet.org, after the
+# full test suite passes. Authentication is Trusted Publishing (GitHub OIDC, no stored API key):
+# NuGet/login exchanges this workflow's identity for a short-lived key. Requirements:
+#   - a Trusted Publishing policy on nuget.org for this repository and this workflow file
+#   - the NUGET_USER repository variable set to the nuget.org username that owns the policy
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Derive version from tag
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Test
+        run: dotnet test Source/Morris.Roslynk.slnx --configuration Release
+
+      - name: Pack
+        run: >
+          dotnet pack Source/App/Morris.Roslynk.Mcp/Morris.Roslynk.Mcp.csproj
+          --configuration Release
+          -p:Version=$VERSION
+          --output ./nupkgs
+
+      - name: NuGet login (Trusted Publishing)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push
+        run: >
+          dotnet nuget push ./nupkgs/*.nupkg
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Peter Morris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 **Roslyn + link** — the link between Claude and Roslyn.
 
-Roslynk is a Windows service that gives an MCP client (e.g. Claude) semantic intelligence over C#
-code via Roslyn: diagnostics, symbol navigation, find-references, semantic rename, code actions,
-dead-code detection and more — operating directly on the projects compiled in a loaded solution.
+Roslynk gives an MCP client (e.g. Claude) semantic intelligence over C# code via Roslyn:
+diagnostics, symbol navigation, find-references, semantic rename, code actions, dead-code detection
+and more — operating directly on the projects compiled in a loaded solution.
 
 - **Transport:** HTTP only, bound to loopback (`127.0.0.1`/`::1`).
-- **Host:** a headless Windows service that starts with the OS. No UI.
+- **Host:** foreground console on Linux/WSL/macOS; on Windows, also installable as a headless service. No UI.
 - **Observability:** OpenTelemetry, exported via OTLP to a backend you configure.
 
 See [Requirements.md](Requirements.md) for the full design.
@@ -27,6 +27,26 @@ Source/
 ## Build
 
 ```
-dotnet build Source/App/Morris.Roslynk.slnx
-dotnet test  Source/App/Morris.Roslynk.slnx
+dotnet build Source/Morris.Roslynk.slnx
+dotnet test  Source/Morris.Roslynk.slnx
 ```
+
+## Run (Linux / WSL / macOS)
+
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download) on `PATH`.
+
+```bash
+./installer/run.sh
+```
+
+Listens on `http://localhost:6502`. Point your MCP client at that URL (streamable HTTP). Ctrl+C stops it.
+
+## Run (Windows)
+
+Foreground dev:
+
+```powershell
+dotnet run --project Source/App/Morris.Roslynk.Mcp
+```
+
+Installed service: see [Source/WindowsServiceInstaller/README.md](Source/WindowsServiceInstaller/README.md).

--- a/README.md
+++ b/README.md
@@ -31,9 +31,34 @@ dotnet build Source/Morris.Roslynk.slnx
 dotnet test  Source/Morris.Roslynk.slnx
 ```
 
-## Run (Linux / WSL / macOS)
+## Connect an MCP client (all platforms)
 
-Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download) on `PATH`.
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download) on `PATH`. The `stdio` verb is a
+self-launching bridge: the MCP client spawns it, it starts the shared HTTP daemon on
+`localhost:6502` if one isn't already running, and pipes the session through. Nothing to launch or
+babysit by hand.
+
+From the published NuGet package (no clone, no build):
+
+```bash
+claude mcp add roslynk -- dnx Roslynk --yes -- stdio
+```
+
+From a source checkout:
+
+```bash
+claude mcp add roslynk -- dotnet run --project /path/to/Roslynk/Source/App/Morris.Roslynk.Mcp -- stdio
+```
+
+(With a published build, use `Morris.Roslynk.Mcp stdio` as the command instead — it starts faster.)
+
+The daemon outlives individual sessions so Roslyn workspaces stay warm across clients. Its console
+output goes to `Roslynk/daemon.log` under the local application-data folder (`~/.local/share` on
+Linux, `~/Library/Application Support` on macOS, `%LOCALAPPDATA%` on Windows).
+
+## Run the daemon manually (Linux / WSL / macOS)
+
+For a foreground daemon with visible logs:
 
 ```bash
 ./installer/run.sh

--- a/Source/App/Morris.Roslynk.Mcp/Hosting/DaemonLauncher.cs
+++ b/Source/App/Morris.Roslynk.Mcp/Hosting/DaemonLauncher.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Morris.Roslynk.Mcp.Hosting;
+
+/// <summary>
+/// Ensures the Roslynk HTTP daemon is listening on the loopback port, starting it detached when it
+/// is not (the Gradle-daemon pattern: the first client to arrive boots the shared host). The spawned
+/// daemon outlives the launcher so its warm workspaces are shared by later sessions; its console
+/// output goes to <see cref="LogFilePath"/>, never to the launcher's stdio channel.
+/// </summary>
+public static class DaemonLauncher
+{
+	private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(30);
+	private static readonly TimeSpan ProbeTimeout = TimeSpan.FromMilliseconds(500);
+
+	public static string LogFilePath => Path.Combine(
+		Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+		"Roslynk",
+		"daemon.log");
+
+	public static async Task EnsureRunningAsync(int port, CancellationToken cancellationToken)
+	{
+		if (await IsListeningAsync(port, cancellationToken))
+			return;
+
+		StartDetached();
+
+		using var startupWindow = new CancellationTokenSource(StartupTimeout);
+		using var linked = CancellationTokenSource.CreateLinkedTokenSource(startupWindow.Token, cancellationToken);
+		while (!await IsListeningAsync(port, linked.Token))
+		{
+			try
+			{
+				await Task.Delay(200, linked.Token);
+			}
+			catch (OperationCanceledException) when (startupWindow.IsCancellationRequested)
+			{
+				throw new TimeoutException(
+					$"The Roslynk daemon did not start listening on port {port} within " +
+					$"{StartupTimeout.TotalSeconds:0}s; see '{LogFilePath}' for its output.");
+			}
+		}
+	}
+
+	private static async Task<bool> IsListeningAsync(int port, CancellationToken cancellationToken)
+	{
+		using var probe = new TcpClient();
+		try
+		{
+			await probe.ConnectAsync(IPAddress.Loopback, port, cancellationToken).AsTask().WaitAsync(ProbeTimeout, cancellationToken);
+			return true;
+		}
+		catch (Exception exception) when (exception is SocketException or TimeoutException)
+		{
+			return false;
+		}
+	}
+
+	private static void StartDetached()
+	{
+		(string executable, string? firstArgument) = DaemonCommand();
+
+		Directory.CreateDirectory(Path.GetDirectoryName(LogFilePath)!);
+
+		// The working directory is the executable's folder so the daemon finds its appsettings.json
+		// regardless of where the MCP client launched the bridge from.
+		ProcessStartInfo startInfo;
+		if (OperatingSystem.IsWindows())
+		{
+			startInfo = new ProcessStartInfo(executable)
+			{
+				UseShellExecute = true,
+				WindowStyle = ProcessWindowStyle.Hidden,
+				WorkingDirectory = AppContext.BaseDirectory,
+			};
+			if (firstArgument is not null)
+				startInfo.ArgumentList.Add(firstArgument);
+		}
+		else
+		{
+			// nohup + shell backgrounding reparents the daemon away from the launcher, and the
+			// redirect keeps its console output out of the stdio JSON-RPC channel.
+			startInfo = new ProcessStartInfo("/bin/sh")
+			{
+				ArgumentList =
+				{
+					"-c",
+					"""nohup "$0" ${2:+"$2"} >>"$1" 2>&1 </dev/null &""",
+					executable,
+					LogFilePath,
+					firstArgument ?? "",
+				},
+				UseShellExecute = false,
+				WorkingDirectory = AppContext.BaseDirectory,
+			};
+		}
+
+		// If two bridges race, the loser's daemon fails to bind the port and exits; both bridges
+		// then connect to the winner, so the race is benign.
+		Process.Start(startInfo);
+	}
+
+	/// <summary>
+	/// The command that starts the daemon. Launched directly (apphost) the process re-runs itself;
+	/// launched as a dotnet tool (dnx / dotnet tool exec) the process is the 'dotnet' host, so the
+	/// daemon must be started as 'dotnet <entry-assembly.dll>' instead.
+	/// </summary>
+	private static (string Executable, string? FirstArgument) DaemonCommand()
+	{
+		string executable = Environment.ProcessPath
+			?? throw new InvalidOperationException("Cannot determine the Roslynk executable path to start the daemon.");
+
+		string processName = Path.GetFileNameWithoutExtension(executable);
+		if (!processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+			return (executable, null);
+
+		string entryAssembly = System.Reflection.Assembly.GetEntryAssembly()?.Location is { Length: > 0 } location
+			? location
+			: throw new InvalidOperationException("Cannot determine the Roslynk assembly path to start the daemon.");
+
+		return (executable, entryAssembly);
+	}
+}

--- a/Source/App/Morris.Roslynk.Mcp/Hosting/StdioBridge.cs
+++ b/Source/App/Morris.Roslynk.Mcp/Hosting/StdioBridge.cs
@@ -1,0 +1,66 @@
+using ModelContextProtocol;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+
+namespace Morris.Roslynk.Mcp.Hosting;
+
+/// <summary>
+/// The `stdio` entry point: an MCP stdio endpoint that clients launch themselves, bridging one
+/// session to the persistent HTTP daemon and starting the daemon on first use. The daemon keeps the
+/// warm shared workspaces the HTTP-only design exists for; stdio is only the doorbell and the pipe,
+/// so a client config needs nothing beyond the launch command.
+/// </summary>
+public static class StdioBridge
+{
+	public static async Task RunAsync()
+	{
+		int port = ResolvePort();
+
+		await DaemonLauncher.EnsureRunningAsync(port, CancellationToken.None);
+
+		var transport = new HttpClientTransport(new HttpClientTransportOptions
+		{
+			Endpoint = new Uri($"http://localhost:{port}"),
+			TransportMode = HttpTransportMode.StreamableHttp,
+			Name = "Roslynk daemon",
+		});
+
+		// Disposing the client on the way out sends the session DELETE, so the daemon releases this
+		// session's solution ref-counts and idle eviction can reclaim the workspaces.
+		await using McpClient daemon = await McpClient.CreateAsync(transport);
+
+		// An empty builder registers no logging providers: nothing may write to stdout but JSON-RPC.
+		HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(settings: null);
+		builder.Services
+			.AddMcpServer(options =>
+			{
+				options.ServerInfo = daemon.ServerInfo;
+				options.ServerInstructions = daemon.ServerInstructions;
+			})
+			.WithStdioServerTransport()
+			.WithListToolsHandler(async (context, cancellationToken) =>
+				await daemon.ListToolsAsync(context.Params ?? new ListToolsRequestParams(), cancellationToken))
+			.WithCallToolHandler(async (context, cancellationToken) =>
+				await daemon.CallToolAsync(
+					context.Params ?? throw new McpException("tools/call requires parameters."),
+					cancellationToken));
+
+		using IHost host = builder.Build();
+		await host.RunAsync();
+	}
+
+	/// <summary>
+	/// Resolves the daemon port from the same sources the daemon itself reads (appsettings.json next
+	/// to the executable plus environment variables), so bridge and daemon always agree.
+	/// </summary>
+	private static int ResolvePort()
+	{
+		IConfigurationRoot configuration = new ConfigurationBuilder()
+			.SetBasePath(AppContext.BaseDirectory)
+			.AddJsonFile("appsettings.json", optional: true)
+			.AddEnvironmentVariables()
+			.Build();
+
+		return configuration.GetValue("Roslynk:Port", LoopbackOnlyExtensions.DefaultPort);
+	}
+}

--- a/Source/App/Morris.Roslynk.Mcp/Morris.Roslynk.Mcp.csproj
+++ b/Source/App/Morris.Roslynk.Mcp/Morris.Roslynk.Mcp.csproj
@@ -1,11 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+	<PropertyGroup>
+		<!-- The Web SDK defaults IsPackable to false; this project ships as a dotnet tool. -->
+		<IsPackable>true</IsPackable>
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>roslynk</ToolCommandName>
+		<PackageId>Roslynk</PackageId>
+		<!-- CI overrides Version from the release tag; this is only the local-build fallback. -->
+		<Version>0.0.1-local</Version>
+		<Description>Roslynk MCP server: C# semantic intelligence over Roslyn. Run with 'dnx Roslynk -- stdio' as an MCP stdio command; it self-starts a shared local daemon.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/mrpmorris/Roslynk</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/mrpmorris/Roslynk</RepositoryUrl>
+		<PackageTags>mcp;roslyn;csharp;model-context-protocol</PackageTags>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RollForward>LatestMajor</RollForward>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Morris.Roslynk\Morris.Roslynk.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+	  <PackageReference Include="ModelContextProtocol" />
 	  <PackageReference Include="ModelContextProtocol.AspNetCore" />
 	  <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 	  <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/Source/App/Morris.Roslynk.Mcp/Program.cs
+++ b/Source/App/Morris.Roslynk.Mcp/Program.cs
@@ -4,6 +4,14 @@ using Morris.Roslynk.Mcp;
 using Morris.Roslynk.Mcp.Hosting;
 using Morris.Roslynk.Mcp.Observability;
 
+// `stdio` runs the client-launched bridge instead of the daemon: it starts the daemon if needed
+// and pipes one MCP session to it over HTTP.
+if (args is ["stdio", ..])
+{
+	await StdioBridge.RunAsync();
+	return;
+}
+
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Safe on every OS: AddWindowsService only takes effect when the process is launched by the

--- a/Source/App/Morris.Roslynk.Mcp/Program.cs
+++ b/Source/App/Morris.Roslynk.Mcp/Program.cs
@@ -6,6 +6,8 @@ using Morris.Roslynk.Mcp.Observability;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// Safe on every OS: AddWindowsService only takes effect when the process is launched by the
+// Windows Service Control Manager; otherwise it registers nothing.
 builder.Services.AddWindowsService(options => options.ServiceName = "Roslynk");
 
 builder.AddLoopbackOnlyKestrel();

--- a/Source/App/Morris.Roslynk.Tests/Features/Symbols/GetMembersTests/GetMembersTests.cs
+++ b/Source/App/Morris.Roslynk.Tests/Features/Symbols/GetMembersTests/GetMembersTests.cs
@@ -18,6 +18,14 @@ public class GetMembersTests
 	}
 
 	[Fact]
+	public async Task WhenATypeHasPrivateMembers_ThenTheyAreIncluded()
+	{
+		string result = await RunAsync("SimpleLibrary.Holder");
+
+		Assert.Contains("field,_ready", result);
+	}
+
+	[Fact]
 	public async Task WhenAMetadataTypesMembersAreRequested_ThenTheyResolveUnderTheMetadataBucket()
 	{
 		string result = await RunAsync("System.String");
@@ -142,7 +150,6 @@ public class GetMembersTests
 
 	private static async Task<string> RunAsync(
 		string typeName,
-		bool includePrivate = false,
 		bool includeInherited = false,
 		string? nameFilter = null,
 		bool includeMethods = true,
@@ -158,7 +165,6 @@ public class GetMembersTests
 		return await subject.GetMembers(
 			TestSolutions.Simple,
 			typeName,
-			includePrivate,
 			includeInherited,
 			nameFilter,
 			includeMethods,

--- a/Source/App/Morris.Roslynk.Tests/Infrastructure/Lifecycle/SolutionKeyTests/EqualityTests.cs
+++ b/Source/App/Morris.Roslynk.Tests/Infrastructure/Lifecycle/SolutionKeyTests/EqualityTests.cs
@@ -5,13 +5,19 @@ namespace Morris.Roslynk.Tests.Infrastructure.Lifecycle.SolutionKeyTests;
 public class EqualityTests
 {
 	[Fact]
-	public void WhenPathsDifferOnlyInCase_ThenKeysAreEqual()
+	public void WhenPathsDifferOnlyInCase_ThenEqualityFollowsThePlatformCasePolicy()
 	{
-		SolutionKey first = SolutionKey.For(@"C:\Solutions\App\App.slnx");
-		SolutionKey second = SolutionKey.For(@"C:\solutions\app\APP.SLNX");
+		string firstPath = OperatingSystem.IsWindows() ? @"C:\Solutions\App\App.slnx" : "/Solutions/App/App.slnx";
+		string secondPath = OperatingSystem.IsWindows() ? @"C:\solutions\app\APP.SLNX" : "/solutions/app/APP.SLNX";
 
-		Assert.Equal(first, second);
-		Assert.Equal(first.GetHashCode(), second.GetHashCode());
+		SolutionKey first = SolutionKey.For(firstPath);
+		SolutionKey second = SolutionKey.For(secondPath);
+
+		bool expectEqual = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
+		Assert.Equal(expectEqual, first.Equals(second));
+		if (expectEqual)
+			Assert.Equal(first.GetHashCode(), second.GetHashCode());
 	}
 
 	[Fact]

--- a/Source/App/Morris.Roslynk.Tests/Infrastructure/Workspaces/SolutionRelativePathTests.cs
+++ b/Source/App/Morris.Roslynk.Tests/Infrastructure/Workspaces/SolutionRelativePathTests.cs
@@ -4,10 +4,13 @@ namespace Morris.Roslynk.Tests.Infrastructure.Workspaces;
 
 public class SolutionRelativePathTests
 {
+	private static string Abs(params string[] segments) =>
+		Path.Combine(OperatingSystem.IsWindows() ? @"C:\" : "/", Path.Combine(segments));
+
 	[Fact]
 	public void WhenThePathIsUnderTheSolutionDirectory_ThenItIsMadeRelativeWithForwardSlashes()
 	{
-		string? result = SolutionRelativePath.Of(@"C:\sln", @"C:\sln\src\App.cs");
+		string? result = SolutionRelativePath.Of(Abs("sln"), Abs("sln", "src", "App.cs"));
 
 		Assert.Equal("src/App.cs", result);
 	}
@@ -15,7 +18,7 @@ public class SolutionRelativePathTests
 	[Fact]
 	public void WhenThePathIsOutsideTheSolutionDirectory_ThenItWalksOutWithDotDot()
 	{
-		string? result = SolutionRelativePath.Of(@"C:\sln\app", @"C:\sln\shared\Linked.cs");
+		string? result = SolutionRelativePath.Of(Abs("sln", "app"), Abs("sln", "shared", "Linked.cs"));
 
 		Assert.Equal("../shared/Linked.cs", result);
 	}
@@ -23,15 +26,17 @@ public class SolutionRelativePathTests
 	[Fact]
 	public void WhenTheSolutionDirectoryIsUnknown_ThenTheAbsolutePathIsReturnedWithForwardSlashes()
 	{
-		string? result = SolutionRelativePath.Of((string?)null, @"C:\sln\src\App.cs");
+		string absolutePath = Abs("sln", "src", "App.cs");
 
-		Assert.Equal("C:/sln/src/App.cs", result);
+		string? result = SolutionRelativePath.Of((string?)null, absolutePath);
+
+		Assert.Equal(absolutePath.Replace('\\', '/'), result);
 	}
 
 	[Fact]
 	public void WhenThePathIsNull_ThenNullIsReturned()
 	{
-		string? result = SolutionRelativePath.Of(@"C:\sln", null);
+		string? result = SolutionRelativePath.Of(Abs("sln"), null);
 
 		Assert.Null(result);
 	}
@@ -39,32 +44,34 @@ public class SolutionRelativePathTests
 	[Fact]
 	public void WhenToAbsoluteIsGivenARootedPath_ThenItIsReturnedAsIs()
 	{
-		string result = SolutionRelativePath.ToAbsolute(@"C:\sln", @"C:\other\App.cs");
+		string rootedPath = Abs("other", "App.cs");
 
-		Assert.Equal(@"C:\other\App.cs", result);
+		string result = SolutionRelativePath.ToAbsolute(Abs("sln"), rootedPath);
+
+		Assert.Equal(rootedPath, result);
 	}
 
 	[Fact]
 	public void WhenToAbsoluteIsGivenARelativePath_ThenItIsResolvedAgainstTheSolutionDirectory()
 	{
-		string result = SolutionRelativePath.ToAbsolute(@"C:\sln", Path.Combine("src", "App.cs"));
+		string result = SolutionRelativePath.ToAbsolute(Abs("sln"), Path.Combine("src", "App.cs"));
 
-		Assert.Equal(@"C:\sln\src\App.cs", result);
+		Assert.Equal(Abs("sln", "src", "App.cs"), result);
 	}
 
 	[Fact]
 	public void WhenToAbsoluteIsGivenADotDotPath_ThenItWalksOutOfTheSolutionDirectory()
 	{
-		string result = SolutionRelativePath.ToAbsolute(@"C:\sln\app", Path.Combine("..", "shared", "B.cs"));
+		string result = SolutionRelativePath.ToAbsolute(Abs("sln", "app"), Path.Combine("..", "shared", "B.cs"));
 
-		Assert.Equal(@"C:\sln\shared\B.cs", result);
+		Assert.Equal(Abs("sln", "shared", "B.cs"), result);
 	}
 
 	[Fact]
 	public void WhenToAbsoluteIsGivenForwardSlashes_ThenTheyAreConvertedToTheOsDelimiter()
 	{
-		string result = SolutionRelativePath.ToAbsolute(@"C:\sln", "src/nested/App.cs");
+		string result = SolutionRelativePath.ToAbsolute(Abs("sln"), "src/nested/App.cs");
 
-		Assert.Equal(Path.Combine(@"C:\sln", "src", "nested", "App.cs"), result);
+		Assert.Equal(Abs("sln", "src", "nested", "App.cs"), result);
 	}
 }

--- a/Source/App/Morris.Roslynk/Features/Symbols/GetMembers/GetMembersTool.cs
+++ b/Source/App/Morris.Roslynk/Features/Symbols/GetMembers/GetMembersTool.cs
@@ -49,9 +49,10 @@ public sealed class GetMembersTool
 		  \t\t<file.cs|file.razor>
 		  \t\t\t<memberKind>,<name>,<loc>,<paramType|paramType|...>
 		where kind is one of {OutlineDescriptions.KindList}, {OutlineDescriptions.Loc}; {OutlineDescriptions.ListFieldQuoting}; the loc is empty for a metadata member; the trailing signature is a pipe-delimited list of minimally-qualified parameter types, present only for methods that take parameters. To read a member's
-		body, resolve its path against the solution folder and read startLine through endLine. Private and
-		inherited members are excluded unless requested; narrow a large type with nameFilter (a trailing '*'
-		matches by prefix, otherwise a case-insensitive substring) and the include* kind toggles.
+		body, resolve its path against the solution folder and read startLine through endLine. All
+		accessibilities including private are listed; inherited members are excluded unless requested; narrow
+		a large type with nameFilter (a trailing '*' matches by prefix, otherwise a case-insensitive
+		substring) and the include* kind toggles.
 		{OutlineDescriptions.Project} {OutlineDescriptions.FilePathSplit} {OutlineDescriptions.ErrorBlock} Prefer this over reading the .cs or .razor file; it is the compiler's view,
 		correct across partial classes and (with includeInherited) base types.
 		""")]

--- a/Source/App/Morris.Roslynk/Infrastructure/Lifecycle/SolutionKey.cs
+++ b/Source/App/Morris.Roslynk/Infrastructure/Lifecycle/SolutionKey.cs
@@ -2,11 +2,19 @@ namespace Morris.Roslynk.Infrastructure.Lifecycle;
 
 /// <summary>
 /// A normalized identity for a solution file, used to share one <see cref="RoslynInstance"/> per
-/// solution across sessions. The path is made absolute and compared case-insensitively (Windows).
+/// solution across sessions. The path is made absolute; comparison follows the platform's default
+/// filesystem convention (case-insensitive on Windows and macOS, case-sensitive elsewhere).
+/// Case-insensitive mounts on Linux (e.g. WSL's /mnt/c) are still compared case-sensitively, so
+/// clients there must use a consistent casing per solution.
 /// </summary>
 public readonly struct SolutionKey : IEquatable<SolutionKey>
 {
 	public string FilePath { get; }
+
+	private static StringComparer PathComparer =>
+		OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+			? StringComparer.OrdinalIgnoreCase
+			: StringComparer.Ordinal;
 
 	private SolutionKey(string filePath) => FilePath = filePath;
 
@@ -18,14 +26,12 @@ public readonly struct SolutionKey : IEquatable<SolutionKey>
 		return new SolutionKey(System.IO.Path.GetFullPath(solutionPath));
 	}
 
-	public bool Equals(SolutionKey other) =>
-		string.Equals(FilePath, other.FilePath, StringComparison.OrdinalIgnoreCase);
+	public bool Equals(SolutionKey other) => PathComparer.Equals(FilePath, other.FilePath);
 
 	public override bool Equals(object? obj) =>
 		obj is SolutionKey other && Equals(other);
 
-	public override int GetHashCode() =>
-		StringComparer.OrdinalIgnoreCase.GetHashCode(FilePath);
+	public override int GetHashCode() => PathComparer.GetHashCode(FilePath);
 
 	public override string ToString() => FilePath;
 }

--- a/installer/run.sh
+++ b/installer/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Run Roslynk as a foreground console app on Linux / WSL / macOS.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT/Source/App/Morris.Roslynk.Mcp/Morris.Roslynk.Mcp.csproj"
+
+if ! command -v dotnet >/dev/null 2>&1; then
+	echo "dotnet is not on PATH. Install the .NET 10 SDK first." >&2
+	exit 1
+fi
+
+exec dotnet run --project "$PROJECT" "$@"


### PR DESCRIPTION
## Summary

Two commits that take Roslynk from "Windows service or babysit a terminal" to a one-line MCP install on every platform:

**1. Cross-platform foreground hosting + review fixes (`70ffbca`)**
- `AddWindowsService` stays unconditional — it no-ops off the SCM, and the build-OS conditional compilation it briefly replaced would have stripped service support from `win-x64` artifacts published from Linux/WSL.
- `SolutionKey` now treats macOS as case-insensitive (default APFS), so two casings of one solution file can't spawn duplicate workspaces; the WSL `/mnt/c` caveat is documented.
- `get_members` description no longer claims private members are excluded; regression test added.
- OS-gated and Windows-path-literal tests rewritten to run and assert on every platform instead of silently passing.

**2. Self-launching stdio bridge + dotnet tool publishing (`389ba9d`)**
- New `stdio` verb: a client-launched bridge (Gradle-daemon pattern) that auto-starts the HTTP daemon detached on first use, pipes one MCP session through over streamable HTTP, and leaves the daemon warm for later sessions — preserving the shared-workspace design HTTP-only hosting exists for.
- Packaged as a dotnet tool (`Roslynk`, command `roslynk`), so install is:
  ```
  claude mcp add roslynk -- dnx Roslynk --yes -- stdio
  ```
- The launcher detects dnx/tool hosting and starts the daemon as `dotnet <assembly>`; daemon output goes to a log under local app data, never the JSON-RPC channel.
- `workflow.yml` publishes to NuGet.org on `v*` tags via Trusted Publishing (OIDC, no stored key) after the test suite passes. MIT license added.

## Verification

- Full suite: 238/238 passing on Linux (previously 6 failed there).
- Bridge driven end-to-end over stdio from cold start: daemon auto-spawned, `initialize`/`tools/list`/`tools/call open_solution` round-tripped, daemon survived session exit; second session attached without double-spawn.
- Packed and executed via `dnx Roslynk@0.0.2-test --source <local> --yes -- stdio` — the dotnet-host spawn path verified.

## Before first publish (repo settings, outside this PR)

1. Create the nuget.org Trusted Publishing policy for `mrpmorris/Roslynk`, workflow file `workflow.yml`.
2. Set the `NUGET_USER` repository variable to the policy-owning nuget.org username.
3. Tag `v0.1.0` to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)