### PR TITLE
ci: publish NuGet package to GitHub Packages

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,10 @@
-name: Publish to NuGet
+name: Publish to GitHub Packages
 
-# Pushing a tag like v1.2.3 packs Roslynk at that version and publishes it to NuGet.org, after the
-# full test suite passes. Authentication is Trusted Publishing (GitHub OIDC, no stored API key):
-# NuGet/login exchanges this workflow's identity for a short-lived key. Requirements:
-#   - a Trusted Publishing policy on nuget.org for this repository and this workflow file
-#   - the NUGET_USER repository variable set to the nuget.org username that owns the policy
+# Pushing a tag like v1.2.3 packs Roslynk at that version and publishes it to this repository's
+# GitHub Packages NuGet feed, after the full test suite passes.
+# Consumers add the feed:
+#   https://nuget.pkg.github.com/OWNER/index.json
+# and authenticate with a PAT (read:packages) or GITHUB_TOKEN that can read packages from this private repo.
 on:
   push:
     tags:
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+  packages: write
 
 jobs:
   publish:
@@ -37,15 +37,18 @@ jobs:
           -p:Version=$VERSION
           --output ./nupkgs
 
-      - name: NuGet login (Trusted Publishing)
-        id: login
-        uses: NuGet/login@v1
-        with:
-          user: ${{ vars.NUGET_USER }}
+      - name: Add GitHub Packages source
+        run: >
+          dotnet nuget add source
+          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          --name github
+          --username ${{ github.actor }}
+          --password ${{ secrets.GITHUB_TOKEN }}
+          --store-password-in-clear-text
 
       - name: Push
         run: >
           dotnet nuget push ./nupkgs/*.nupkg
-          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
-          --source https://api.nuget.org/v3/index.json
+          --api-key ${{ secrets.GITHUB_TOKEN }}
+          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
           --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -38,11 +38,20 @@ self-launching bridge: the MCP client spawns it, it starts the shared HTTP daemo
 `localhost:6502` if one isn't already running, and pipes the session through. Nothing to launch or
 babysit by hand.
 
-From the published NuGet package (no clone, no build):
+From the published NuGet package on **GitHub Packages** (this repo is private — no clone, no build):
 
 ```bash
+# One-time: add the private feed (PAT needs read:packages + access to this repo)
+dotnet nuget add source "https://nuget.pkg.github.com/mrpmorris/index.json" \
+  --name github \
+  --username YOUR_GITHUB_USERNAME \
+  --password YOUR_GITHUB_PAT \
+  --store-password-in-clear-text
+
 claude mcp add roslynk -- dnx Roslynk --yes -- stdio
 ```
+
+Tagged releases (`v*`) are packed and pushed to that feed by CI.
 
 From a source checkout:
 


### PR DESCRIPTION
## Summary
- Switch the release workflow from nuget.org Trusted Publishing to this repo's **GitHub Packages** NuGet feed (private repo).
- Use `GITHUB_TOKEN` with `packages: write` instead of NuGet OIDC / `NUGET_USER`.
- Document private feed setup (`read:packages` PAT) and tagged (`v*`) CI publish in the README.

## Test plan
- [ ] Review workflow YAML permissions and push source URL
- [ ] Merge, then push a tag such as `v0.1.0` and confirm the package appears under Packages
- [ ] From another machine: add the GitHub Packages source with a PAT and run `dnx Roslynk --yes -- stdio` (or `dotnet tool install -g Roslynk`)