### PR TITLE
docs: add roslynk skill teaching AI agents effective use of the MCP tools

### DIFF
--- a/skills/roslynk/SKILL.md
+++ b/skills/roslynk/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: roslynk
+description: How to use the Roslynk MCP tools (mcp__roslynk__*) effectively for C# work. Use this whenever a Roslynk server is connected and the task touches C# code in a solution — checking for compile errors or warnings, finding a symbol's definition, references, callers, or implementations, renaming symbols, applying code fixes or refactorings, finding dead code, or editing .cs files — even if the user never says "Roslynk". Consult it before reaching for grep, file reads, hand-written edits, or `dotnet build` on C# code: Roslynk's semantic tools are faster and more correct for all of those jobs.
+---
+
+# Using Roslynk
+
+Roslynk is an MCP server that holds a live Roslyn compilation of a C# solution. Every question you'd normally answer with grep, file reads, or `dotnet build` — "where is this used?", "does it compile?", "rename this safely" — it answers from the compiler's symbol model instead. That matters because text search lies: it hits comments, strings, and unrelated same-named members, and it misses partial classes, generated code, and `#if` branches. Roslynk doesn't.
+
+**Default to Roslynk for C# semantic work.** Fall back to plain file tools only for what Roslynk doesn't cover: non-C# files, file creation/deletion, and reading a method body once you know its location.
+
+## Getting started
+
+1. Call `open_solution` with the absolute path to the `.sln`/`.slnx`. It returns immediately and loads in the background; the `solutionId` it returns (which is just the solution path) is the handle every other tool needs.
+2. If a call returns `error=Indexing`, the load hasn't finished. Retry the same call shortly, or poll `get_solution_status` (~1s interval) and report loading progress. **Do not fall back to reading or editing files directly** — loading finishes within seconds to a minute.
+3. `open_solution` is idempotent and the daemon keeps solutions warm across sessions, so calling it again is cheap and safe.
+
+Never call `reload_solution` on your own initiative. File changes — including edits made by you, the user, or other tools — are picked up automatically by Roslynk's file watcher. If something looks stale (e.g. after a branch switch, `dotnet restore`, or an SDK/props change), *suggest* the user run reload; only call it when they explicitly say so.
+
+## Choosing the right tool
+
+| You want to... | Use | Not |
+|---|---|---|
+| Check whether the code compiles / see warnings | `get_diagnostics` | `dotnet build` (minutes vs. instant) |
+| Find where a symbol is used | `find_references` | grep (false hits in strings/comments) |
+| Find who calls a method | `get_callers` | grep |
+| Jump from a usage to its declaration | `find_definition` (file + line + column) | scrolling files |
+| Find implementations of an interface/abstract member | `find_implementations` | grep |
+| See a type's members and where they're declared | `get_members` | reading the whole file |
+| Identify what a name refers to / get its signature | `get_symbol` | reading files |
+| Explore base types / derived types | `get_type_hierarchy` | manual tracing |
+| Find a symbol by partial name | `search_symbols` | grep across the repo |
+| Rename a symbol everywhere (incl. `.razor`) | `rename_symbol` | find-and-replace |
+| Apply a compiler-suggested fix | `apply_code_fix` / `get_code_actions` → `apply_code_action` | hand-editing |
+| Edit .cs source directly | `apply_patch` (unified diff) | host editor Write/Edit |
+| Remove unused `using` directives | `remove_unused_usings` | hand-editing |
+| Add an optional parameter to a method | `change_signature` | hand-editing call sites |
+| Find unused members / dead `#if` branches | `find_dead_code` / `find_dead_conditionals` | eyeballing |
+
+To read a method's *body*, use `get_members` or `get_symbol` to get the file path and line span, then read just those lines with your normal file-read tool. Roslynk locates; the host reads.
+
+## Addressing symbols
+
+Most tools take a **fully-qualified name**: `Namespace.Type` or `Namespace.Type.Member` (no `global::` prefix). Names also resolve against referenced assemblies, so `System.String.Substring` works.
+
+The intended loop when a name doesn't resolve cleanly:
+
+- `error=Ambiguous` → the response lists `candidate=` lines with exact FQNs. Pick the right one and retry.
+- `error=NotFound` → `candidate=` lines carry fuzzy suggestions. If none fit, try `search_symbols` with a substring.
+
+Two tools are position-based instead (file path + 1-based line and column): `find_definition` (you have a cursor location, not a name) and `get_code_actions` (actions are inherently positional).
+
+## Reading results
+
+Every tool returns a compact text outline, not JSON: `key=value` header lines, then a blank line, then a tab-indented body (project → folders → file → namespace → type → member, with `kind,name,line:col` leaves). Booleans are `Y`/`N`. A `status=` header appears only when the solution isn't Ready — its absence means Ready.
+
+Errors are header-only: `error=<code>` plus `errorMessage=`. Codes you'll act on: `Indexing` (retry same call), `Ambiguous`/`NotFound` (use the `candidate=` lines), `Stale` (re-read the file, recompute your edit), `Conflict` (re-run the discovery step, e.g. `get_code_actions`), `NotSupported`, `Invalid`.
+
+Watch for `truncated=Y`: results were capped (`find_references` defaults to 100, `search_symbols` 50, `find_dead_code` 50). Raise `maxResults` or narrow the query if you need everything.
+
+**Results are snapshots.** The solution is edited live, so re-query rather than reusing an earlier response — especially after any write.
+
+**Leave defaulted parameters alone** unless you specifically need the non-default behavior. One that surprises people: `get_diagnostics`' include flags all default to *false*, but the header always reports `errors=/warnings=/infos=/hidden=` counts — so a bare call is a cheap "does it compile?" check, and you opt into detail (`includeErrors=true`, ...) only when counts are non-zero.
+
+## Editing code
+
+All write tools (`apply_patch`, `rename_symbol`, `apply_code_action`, `apply_code_fix`, `remove_unused_usings`, `change_signature`) share these behaviors:
+
+- **`checkOnly=true` previews** the changed-file list without writing. Use it when a change might be broad (a rename of a widely-used symbol) or when you want to confirm scope before committing.
+- Writes are **atomic and stale-guarded**: if a target file changed on disk since Roslynk read it, the whole batch is rejected with `error=Stale` rather than clobbering the concurrent edit. On `Stale`, just recompute from current state and retry.
+- Writes go straight to disk and the in-memory model advances with them, so a `get_diagnostics` immediately after a write reflects the change — no reload, no rebuild step.
+
+Prefer `apply_patch` over the host editor's Write/Edit for `.cs` files that are compiled in the solution — it keeps Roslynk's model in sync and gets you the stale-write protection. Its rules:
+
+- Standard git unified diff, but hunks are **content-anchored, not line-number-anchored** — include enough surrounding context that each hunk matches exactly one place, or you'll get `error=Conflict`.
+- It edits **existing solution-compiled .cs files only**. File creation, deletion, and non-.cs files are rejected (`error=NotSupported`) — use the host editor for those.
+
+### The diagnostics loop
+
+The core edit cycle: make a change (via any write tool) → `get_diagnostics` (bare call, read the counts) → if errors appeared, `includeErrors=true` to see them → fix → repeat. This replaces `dotnet build` entirely during development; results are effectively instant because the compilation is already in memory. Pass `includeAnalyzers=false` for an even faster compiler-only pass when you don't care about style rules yet.
+
+### Fixing diagnostics
+
+Two paths:
+
+- **Quick path** — you already know the diagnostic ID (from `get_diagnostics`): `apply_code_fix(documentPath, diagnosticId)` fixes the first occurrence of that ID in the file. One call, no handle juggling.
+- **Full path** — you want to see what's on offer at a location: `get_code_actions(documentPath, line, column)` lists fixes and refactorings with opaque `actionId`s; pass one verbatim to `apply_code_action`. Action IDs aren't cached server-side — if the code changed in between, you'll get `error=Conflict`; re-run `get_code_actions` and pick again.
+
+### Rename and signature changes
+
+`rename_symbol` is compiler-correct across partial classes, all `#if` branches, every target framework, and **Razor**: usages in `.razor`/`.cshtml` markup and `@code` blocks are rewritten in the actual Razor source. Trust it over any textual replace. The new name must be a valid C# identifier.
+
+`change_signature` (v1) does exactly one thing: append a single *optional* parameter to an ordinary method, optionally threading an argument into every call site. It refuses virtual/override/abstract/interface/partial methods, overloaded methods, constructors, and operators — for those, fall back to `apply_patch` plus `find_references` to update call sites yourself.
+
+### Dead-code cleanup
+
+`find_dead_code` reports candidates with `High`/`Medium` confidence and a reason — it never deletes. It already excludes interface implementations, overrides, test methods, generated code, and DI-attributed members, but treat results as *candidates*: public API may be used externally, reflection can hide uses. Confirm intent with the user before bulk-deleting. The reported `loc` is the full declaration span, ready to hand to `apply_patch` for removal. On large solutions pass `scope` (an FQN prefix) — the scan is per-symbol and whole-solution scans are slow. `find_dead_conditionals` similarly flags `#if` branches never compiled under any loaded configuration, with the caveat that configurations Roslynk hasn't loaded (CI-only defines, missing workloads) can produce false positives.
+
+## Limits to remember
+
+- Roslynk covers **.cs files compiled in the loaded solution** (plus Razor via its generated code, read-mostly — only `rename_symbol` writes back to `.razor`/`.cshtml`). Everything else — csproj, json, md, new files — is the host's job.
+- `search_symbols` searches source-declared symbols only, not referenced assemblies; `get_symbol`/FQN resolution *does* reach metadata.
+- Multi-targeted projects: pin `get_diagnostics` with `targetFramework` if you need one TFM's view.
+
+For exact parameter lists, output shapes, and per-tool gotchas, read [references/tools.md](references/tools.md).

--- a/skills/roslynk/references/tools.md
+++ b/skills/roslynk/references/tools.md
@@ -1,0 +1,126 @@
+# Roslynk tool reference
+
+Detailed per-tool reference. Read the section you need; SKILL.md carries the workflows.
+
+## Contents
+
+- [Shared conventions](#shared-conventions)
+- [Lifecycle: open_solution, get_solution_status, reload_solution](#lifecycle)
+- [Navigation: find_definition, get_symbol, get_members, search_symbols](#navigation)
+- [Relationships: find_references, get_callers, find_implementations, get_type_hierarchy](#relationships)
+- [Diagnostics: get_diagnostics](#diagnostics)
+- [Code actions: get_code_actions, apply_code_action, apply_code_fix](#code-actions)
+- [Editing: apply_patch, rename_symbol, change_signature, remove_unused_usings](#editing)
+- [Dead code: find_dead_code, find_dead_conditionals](#dead-code)
+
+## Shared conventions
+
+**Output format.** Compact text outline: `key=value` header lines, a blank line, then a tab-indented body. No blank line means the response is all headers (typically an error). Booleans render `Y`/`N`. Newlines inside a field are literal `\n`. A `status=` header (`Building`|`Faulted`) appears only when the solution is not Ready.
+
+**Body nesting** (multi-symbol tools): project → one line per folder segment → file → namespace → `typeKind,typeName,loc` → `memberKind,memberName,loc`. `kind` ∈ `method|property|field|event|class|struct|interface|enum|delegate`. `loc` is `line:col` or `startLine:startCol-endLine:endCol`, 1-based; multiple locations on one line are pipe-delimited. Names containing commas (e.g. `Dictionary<string, int>`) are single-quoted.
+
+**Error shape** (header-only):
+
+```
+error=<Indexing|Faulted|NotFound|Ambiguous|NotSupported|Stale|Invalid|Conflict>
+errorMessage=<text>
+candidate=<fqn>        (0+ lines: NotFound suggestions / Ambiguous matches)
+stale=<path>           (0+ lines, Stale only)
+```
+
+**Truncation.** Known-total tools emit `count=<total>` and `truncated=Y` when capped; unknown-total scans (`find_dead_code`) emit only `truncated=Y`.
+
+**Defaults.** Don't pass a value for a defaulted parameter unless you need the non-default behavior.
+
+**`#if` projections.** Symbol tools (find_definition, find_implementations, get_members, get_symbol, get_type_hierarchy, find_references, get_callers, rename_symbol, search_symbols) also cover inactive `#if`/`#else` branches: Roslynk builds derived compilations toggling each uniformly-defined preprocessor symbol, and unions/dedupes results.
+
+## Lifecycle
+
+### open_solution
+`solutionPath` (required): absolute path to `.sln`/`.slnx`.
+Returns `solutionId` (= the path you passed), `status`, `projects`, `loadDiagnostics`, then one `<projectPath>,<documentCount>` line per project. Loads in the background; idempotent; missing file → `NotFound`, failed load → `Faulted`. While loading, other tools return `error=Indexing` — retry them shortly; never fall back to raw file edits.
+
+### get_solution_status
+No parameters. Lists every solution loaded by the daemon (daemon-wide, not session-scoped): `<solutionId>,<status>,<loaded>/<total>` per line. `total` is `?` until the first load completes. Status values: `Building`, `Updating`, `Ready`, `Faulted`.
+
+### reload_solution
+`solutionId` (required). Forces a from-disk MSBuild re-evaluation; the old snapshot keeps serving as `Building` until the fresh one is ready. Manual backstop for missed watcher events (network/WSL filesystems), `dotnet restore`, SDK/`global.json`/`Directory.Build.props` changes, branch switches, or retrying a `Faulted` load. **Never call it unless the user explicitly instructs you to** — suggest it instead.
+
+## Navigation
+
+### find_definition
+`solutionId`, `filePath` (absolute or solution-relative), `line`, `column` (1-based). Position-based go-to-definition. Returns `#fullName`, `#kind`, plus `#project`/`#path`/`#loc` for source symbols or `#assembly=` for metadata-only. (Note the `#`-prefixed header style, unique to this tool family.)
+
+### get_symbol
+`solutionId`, `symbolName` (FQN, any symbol kind including members). Unambiguous source match → `#project`/`#path`/`#loc` headers + body containing the verbatim declaration text cut before the body (brace/`=>` excluded). Metadata symbol → `#source=metadata`, `#kind`, `#signature`, `#assembly`. Ambiguous → a locator tree (project→file→namespace→types→`kind,name,loc`) instead of an error, so pick and retry with a fuller name. Preferred over reading a file to identify a symbol.
+
+### get_members
+`solutionId`, `typeName` (FQN), `includeInherited` (default false), `nameFilter` (default null; trailing `*` = prefix match, otherwise case-insensitive substring), `includeMethods`/`includeFields`/`includeProperties`/`includeEvents`/`includeNestedTypes` (all default true). Lists all members including private, grouped by declaring file (`<metadata>` bucket for referenced-assembly types). Member lines: `kind,name,loc[,paramType|paramType|...]` (param list only for methods with parameters). Returns declarations + spans, not bodies — read `startLine..endLine` of the file for the body.
+
+### search_symbols
+`solutionId`, `query` (case-insensitive substring), `maxResults` (default 50). Source-declared symbols only (no metadata). Matched members nest under their type; a type's `loc` appears only if the type itself matched.
+
+## Relationships
+
+### find_references
+`solutionId`, `symbolName` (FQN), `maxResults` (default 100). Compiler-accurate: skips comments, strings, unrelated same-named members. References grouped file→namespace→type→member; pipe-delimited `loc`s on one line for multiple hits. Deduped across `#if` projections. `count=`/`truncated=Y` when capped.
+
+### get_callers
+`solutionId`, `methodName` (FQN). Callers grouped file→namespace→containing type→calling member with the caller's declaration `loc`. Resolves overloads via the compiler.
+
+### find_implementations
+`solutionId`, `symbolName` (FQN of interface, abstract member, or virtual member). Implementors/overrides across all projections, deduped.
+
+### get_type_hierarchy
+`solutionId`, `typeName` (FQN). Up to three sections — `base`, `interfaces`, `derived` (omitted when empty) — entries `typeKind,FQN`.
+
+## Diagnostics
+
+### get_diagnostics
+`solutionId`, `includeErrors`/`includeWarnings`/`includeInfo`/`includeHidden` (**all default false**), `targetFramework` (optional; pins a multi-targeted project to one compilation), `includeAnalyzers` (default true; `false` = faster compiler-only pass).
+
+Header always carries `errors=`, `warnings=`, `infos=`, `hidden=` counts regardless of include flags, so filtering is never silent — a bare call is a cheap compile check. Body (per included severity) nests file→severity→`<id>,<line:col>,<message>`. Results are cached per `(targetFramework, includeAnalyzers)` and invalidated on any write, so repeated calls are cheap. This replaces `dotnet build` for correctness checking.
+
+## Code actions
+
+### get_code_actions
+`solutionId`, `documentPath` (.cs, absolute or solution-relative), `line`, `column` (1-based), `endLine`/`endColumn` (optional, for a selection span). Returns lines `<actionId>,<kind>,<diagnosticId> <title>`; `kind` ∈ `Fix|Refactoring`; `diagnosticId` is `-` for refactorings. Capped at 50. `actionId` is opaque — pass it back verbatim.
+
+### apply_code_action
+`solutionId`, `actionId` (from get_code_actions), `checkOnly` (default false). The action is re-resolved at apply time, not cached — if the code changed since discovery, `error=Conflict`: re-run `get_code_actions`. Malformed id → `error=Invalid`. Returns `applied`, `action`, changed files.
+
+### apply_code_fix
+`solutionId`, `documentPath`, `diagnosticId` (e.g. `CS0219`), `checkOnly` (default false). Quick path: fixes the first occurrence of that diagnostic in the file without an actionId round-trip. No such diagnostic in the file → `NotFound`; no registered fix → `NotSupported`; fix produced no changes → `Conflict`.
+
+## Editing
+
+All write tools: `checkOnly=true` previews changed files without writing; writes are atomic (all-or-nothing) and stale-guarded (on-disk content re-hashed against the loaded snapshot; mismatch → `error=Stale`, nothing written). Successful writes advance the in-memory model immediately. Response shape: `applied=Y|N` + tool-specific headers + changed-file list grouped by project.
+
+### apply_patch
+`solutionId`, `patch` (git unified diff: `---`/`+++`/`@@` hunks, one or more .cs sections), `baseVersions` (optional list of `{path, version}` from a prior read, for explicit optimistic concurrency), `checkOnly`.
+
+- Hunks are **content-anchored**; line numbers in `@@` headers are untrusted and may be omitted (`@@`). Each hunk must match exactly one place — include enough context. Ambiguous or unmatched → `error=Conflict` naming the file and reason.
+- Edits existing solution-compiled .cs files only. Creation, deletion, and non-.cs targets are rejected before any hunk is attempted: `error=NotSupported` with `rejected=<path>` lines.
+- Path resolution: absolute → solution-relative → unique suffix match across solution documents.
+- The stale-write guard runs even without `baseVersions`.
+
+### rename_symbol
+`solutionId`, `symbolName` (FQN), `newName` (must be a valid C# identifier), `checkOnly`. Renames across partial classes, all `#if` projections, all TFMs, and Razor: edits computed against generated `.g.cs` are mapped back through `#line` directives and written to the real `.razor`/`.cshtml` (covering `@code` blocks, markup expressions, and component attributes in other components). Unverifiable mapping aborts the whole rename before writing. Ambiguous → `error=Ambiguous` with candidates.
+
+### change_signature
+`solutionId`, `methodId` (FQN), `parameterType` (e.g. `System.Threading.CancellationToken`), `parameterName` (valid identifier), `defaultValue` (**required** — keeps the parameter optional, e.g. `default`, `null`, `0`), `callSiteArgument` (optional; when given, threaded into every call site as a named argument), `checkOnly`.
+
+v1 scope: appends one optional parameter to one ordinary method. `NotSupported` for virtual/override/abstract methods, interface members and implementations, partial methods, `params` methods, constructors/operators/accessors/local functions; overloads → `Ambiguous` (cannot target a specific overload). Only true invocation call sites are updated — method groups, `nameof`, and `cref` are left alone (still valid because the parameter is optional). Returns `updatedCallSites` count.
+
+### remove_unused_usings
+`solutionId`, `documentPath` (optional; omit to clean the whole solution), `checkOnly`. Driven by compiler diagnostic CS8019. Nothing to remove → `applied=N`, `removedCount=0` (not an error). Safe to re-run (idempotent).
+
+## Dead code
+
+### find_dead_code
+`solutionId`, `scope` (optional FQN prefix, e.g. `MyApp.Services` — use it on large solutions; the scan runs find-references per symbol), `includePublic` (default false — public/protected API excluded unless set), `maxResults` (default 50).
+
+Leaf lines: `memberKind,memberName,loc,confidence,reason` with confidence `High|Medium`. Automatically excludes interface implementations, virtual/override/abstract chains, test-attributed members (xUnit/NUnit/MSTest), generated code, and DI/reflection-attributed members (`[Export]`, `[ImportingConstructor]`). The `loc` is the full declaration span, ready to pass to `apply_patch` for removal — this tool never deletes anything itself. Treat results as candidates, not verdicts.
+
+### find_dead_conditionals
+`solutionId` only. Header `#deadConditionals=<n>`; body per file: `<line:col>,<directive>,<condition>` with directive ∈ `if|elif|else` (condition `(else)` for `#else`). Flags branches never compiled under any configuration Roslynk actually loaded (each project's defined symbols, and that set minus DEBUG, across TFMs). A branch used only by a configuration not loaded (CI-injected define, missing workload) is a false positive — treat as "possibly dead".


### PR DESCRIPTION
## Summary

Adds a skill at `skills/roslynk/` that teaches AI agents (Claude Code and other MCP-aware harnesses) how to use the Roslynk tools effectively:

- **`SKILL.md`** — the core guide: preferring semantic tools over grep/`dotnet build`/hand-edits, solution lifecycle (Indexing retries, never self-calling `reload_solution`), a task→tool selection table, fully-qualified-name addressing with the `Ambiguous`/`NotFound` candidate-retry loop, outline/error format, write safety (`checkOnly`, `Stale` recovery, content-anchored `apply_patch`), the diagnostics loop, and Razor/dead-code caveats.
- **`references/tools.md`** — full per-tool reference (parameters, defaults, output shapes, error cases), loaded only when needed to keep context cost low.

## Why

Benchmarked with/without the skill on three real tasks against this solution (compile check, find-usages, rename impact preview). The unguided baseline found the MCP tools for read-only queries, but for the rename preview it fell back to grep and described its own output as "a strong estimate rather than a guarantee" — the with-skill run used `rename_symbol` `checkOnly=true` and matched the compiler-verified 22-file impact list by construction. With-skill passed 12/12 graded assertions vs 11/12 baseline.

Docs-only change: no package content is affected, so no version bump/release is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)